### PR TITLE
Change notification policy for the sleeping blocks

### DIFF
--- a/monitor/Alert.ts
+++ b/monitor/Alert.ts
@@ -49,6 +49,18 @@ export class NodeIsSleeping implements CodeChainAlert {
   }
 }
 
+export class NodeRecovered implements CodeChainAlert {
+  public title: string;
+  public content: string;
+
+  constructor(blockNumber: number, nodeIndex: number, sleepStreak: number) {
+    const suffix = `${new Date().toISOString()}`;
+    this.title = `${prefix} CodeChain Node has recovered from the problem ${suffix}`;
+    this.content = `The node ${nodeIndex} did not precommit from the block ${blockNumber -
+      sleepStreak} consecutively. Now the node ${nodeIndex} has been recovered from the problem.`;
+  }
+}
+
 export class AllNodesAwake implements CodeChainAlert {
   public title: string;
   public content: string;


### PR DESCRIPTION
Previously when nodes attained sleepStreak more than the
sleepStreakAlertLevel, monitor sent a notification. But if a node dies,
the monitor will send notifications forever because the node starts to stack
the sleepingStreak forever. Now the policy has been changed so that not
to send notifications forever but to send a notification when
sleepStreak starts to exceed the sleepStreakAlertLevel or has been
recovered from the problem.