### PR TITLE
Support Dynamic Validators in Monitor

### DIFF
--- a/monitor/Notification.ts
+++ b/monitor/Notification.ts
@@ -44,14 +44,18 @@ export class NodeIsSleeping implements Notification {
   public readonly level = "warn";
   public readonly date = new Date();
 
-  constructor(blockNumber: number, nodeIndices: number[], streak?: number) {
+  constructor(
+    blockNumber: number,
+    validatorAddresses: string[],
+    streak?: number
+  ) {
     const prefix = `[${this.level}][${networkId}][monitor]`;
     this.title = `${prefix} CodeChain Node is Sleeping`;
     if (streak !== undefined) {
       this.content = `Consecutive ${streak} blocks from the block(${blockNumber -
-        streak}), validating nodes ${nodeIndices} did not precommit.`;
+        streak}), validators ${validatorAddresses} did not precommit.`;
     } else {
-      this.content = `For the block(${blockNumber}), validating nodes ${nodeIndices} did not precommit.`;
+      this.content = `For the block(${blockNumber}), validators ${validatorAddresses} did not precommit.`;
     }
   }
 }
@@ -62,11 +66,15 @@ export class NodeRecovered implements Notification {
   public readonly level = "info";
   public readonly date = new Date();
 
-  constructor(blockNumber: number, nodeIndex: number, sleepStreak: number) {
+  constructor(
+    blockNumber: number,
+    validatorAddress: string,
+    sleepStreak: number
+  ) {
     const prefix = `[${this.level}][${networkId}][monitor]`;
     this.title = `${prefix} CodeChain Node has recovered from the problem`;
-    this.content = `The node ${nodeIndex} did not precommit from the block ${blockNumber -
-      sleepStreak} consecutively. Now the node ${nodeIndex} has been recovered from the problem.`;
+    this.content = `The validator ${validatorAddress} did not precommit from the block ${blockNumber -
+      sleepStreak} consecutively. Now the validator ${validatorAddress} has been recovered from the problem.`;
   }
 }
 

--- a/monitor/index.ts
+++ b/monitor/index.ts
@@ -175,13 +175,13 @@ const checkSealField = (() => {
     const bestBlock = await sdk.rpc.chain.getBlock(bestBlockNumber);
     if (bestBlock) {
       // FIXME: When dynatmic validator is deployed, get validator count dynamically.
-      const currentViewIdx = 1;
-      const precommitBitsetIdx = 3;
+      const CURRENT_VIEW_IDX = 1;
+      const PRECOMMIT_BITSET_IDX = 3;
       const bestBlockSealField = bestBlock.seal;
 
-      const currentView = decodeViewField(bestBlockSealField[currentViewIdx]);
+      const currentView = decodeViewField(bestBlockSealField[CURRENT_VIEW_IDX]);
       const precommitBitset = decodeBitsetField(
-        bestBlockSealField[precommitBitsetIdx]
+        bestBlockSealField[PRECOMMIT_BITSET_IDX]
       );
       const sleepingNodeIndices = unsetBitIndices(
         precommitBitset,


### PR DESCRIPTION
We do not need to handle term change especially.
When the term is changed, outcast validators will be removed from the "sleepingValidators".

Fix https://github.com/CodeChain-io/cron-jobs/issues/59