### PR TITLE
Divide notifications into two routes

### DIFF
--- a/fee-monitor/src/DynamicChecker.ts
+++ b/fee-monitor/src/DynamicChecker.ts
@@ -1,5 +1,5 @@
 import { CCCTracer, getCCCBalances, SettleMoment } from "./CCC";
-import { slack, email, sdk, SERVER } from "./config";
+import { slack, sdk, SERVER } from "./config";
 import {
     PlatformAddress,
     U64,
@@ -356,13 +356,6 @@ export class DynamicChecker {
 
         if (aggregated.errors.length > 0) {
             slack.sendWarning(JSON.stringify(aggregated, null, "    "));
-            const errors = aggregated.errors
-                .map(error => `<li>${JSON.stringify(error)}</li>`)
-                .join("<br />\r\n");
-            email.sendWarning(`
-            <p>${positionString}</p>
-            <ul>${errors}</ul>
-            `);
         } else {
             console.log(`${positionString} is Okay`);
         }

--- a/fee-monitor/src/index.ts
+++ b/fee-monitor/src/index.ts
@@ -139,7 +139,6 @@ function createWatchdog(timeout: number): Watchdog<Progress> {
             console.warn(message);
             const title = "has been recovered to normal.";
             slack.sendInfo(title, message);
-            email.sendInfo(title, message);
         }
     });
     return dog;
@@ -167,12 +166,12 @@ async function main() {
             }
             const reports = [];
             reports.push(
-                `<p>Block between ${lastReportedBlockNumber} ~ ${currentBlockNumber} are checked</p>`,
+                `Block between ${lastReportedBlockNumber} ~ ${currentBlockNumber} are checked`,
             );
-            reports.push(`<h3>Stakeholders</h3>`);
-            reports.push(`<ul>${stakeholders.join("<br />\r\n")}</ul>`);
+            reports.push(`Stakeholders`);
+            reports.push(`${stakeholders.join("\r\n")}`);
 
-            email.sendInfo("is working.", `${reports.join("\r\n")}`);
+            slack.sendInfo("is working.", `${reports.join("\r\n")}`);
             lastReportedDate = now.getUTCDate();
             lastReportedBlockNumber = currentBlockNumber;
         })().catch(console.error);

--- a/indexer-monitor/src/index.ts
+++ b/indexer-monitor/src/index.ts
@@ -34,13 +34,15 @@ function sendNotice(error: Notification, targetEmail: string) {
             color,
         });
     }
-    emailClient
-        .sendAnnouncement(
-            targetEmail,
-            `${error.title} - ${error.date.toISOString()}`,
-            error.content,
-        )
-        .catch(console.error);
+    if (error.level === "error") {
+        emailClient
+            .sendAnnouncement(
+                targetEmail,
+                `${error.title} - ${error.date.toISOString()}`,
+                error.content,
+            )
+            .catch(console.error);
+    }
 }
 
 const checkDayChange = (() => {

--- a/monitor/index.ts
+++ b/monitor/index.ts
@@ -43,13 +43,15 @@ function sendNotice(error: Notification, targetEmail: string) {
       color
     });
   }
-  emailClient
-    .sendAnnouncement(
-      targetEmail,
-      `${error.title} - ${error.date.toISOString()}`,
-      error.content
-    )
-    .catch(console.error);
+  if (error.level === "error") {
+    emailClient
+      .sendAnnouncement(
+        targetEmail,
+        `${error.title} - ${error.date.toISOString()}`,
+        error.content
+      )
+      .catch(console.error);
+  }
 }
 
 const checkDeath = (() => {


### PR DESCRIPTION
Now only "error" level notifications are sent to email and the others are sent to slack channel.
it closes #108 