### PR TITLE
Unify environment variable name between tools

### DIFF
--- a/fee-monitor/src/config.ts
+++ b/fee-monitor/src/config.ts
@@ -42,7 +42,10 @@ export const sdk = (() => {
     });
 })();
 
-export const slack = createSlack(`[${networkId(SERVER)}][fee-monitor]`, process.env.SLACK);
+export const slack = createSlack(
+    `[${networkId(SERVER)}][fee-monitor]`,
+    process.env.SLACK_WEBHOOK_URL,
+);
 export const email = createEmail({
     tag: `[${networkId(SERVER)}][fee-monitor]`,
     sendgridApiKey: process.env.SENDGRID_API_KEY,

--- a/indexer-monitor/src/index.ts
+++ b/indexer-monitor/src/index.ts
@@ -349,7 +349,7 @@ async function main() {
 
     const indexerUrl = getConfig("INDEXER_URL");
     const indexerAPI = new IndexerAPIImpl(indexerUrl);
-    const targetEmail = getConfig("NOTIFICATION_TARGET_EMAIL");
+    const targetEmail = getConfig("SENDGRID_TO");
 
     try {
         await indexerAPI.ping();

--- a/monitor/index.ts
+++ b/monitor/index.ts
@@ -287,7 +287,7 @@ const checkSealField = (() => {
 async function main() {
   const rpcUrl = getConfig("RPC_URL");
   const rpc = new Rpc(rpcUrl);
-  const targetEmail = getConfig("NOTIFICATION_TARGET_EMAIL");
+  const targetEmail = getConfig("SENDGRID_TO");
 
   const networkId = await rpc.chain.getNetworkId();
 
@@ -304,7 +304,7 @@ async function main() {
 process.on("unhandledRejection", error => {
   const rpcUrl = getConfig("RPC_URL");
   const rpc = new Rpc(rpcUrl);
-  const targetEmail = getConfig("NOTIFICATION_TARGET_EMAIL");
+  const targetEmail = getConfig("SENDGRID_TO");
   rpc.chain
     .getNetworkId()
     .then(networkId => {

--- a/regulated-assets/src/configs.ts
+++ b/regulated-assets/src/configs.ts
@@ -140,4 +140,4 @@ export const TIMEOUT: number = (() => {
     }
 })();
 
-export const slack = createSlack(process.env.SLACK);
+export const slack = createSlack(process.env.SLACK_WEBHOOK_URL);


### PR DESCRIPTION
Parsing target envrionment variable name `SLACK` or `SLACK_WEBHOOK_URL` are unified to `SLACK_WEBHOOK_URL` and `SENDGRID_TO` or `NOTIFICATION_TARGET_EMAIL` are unified to `SENDGRID_TO`.