### PR TITLE
[indexer-monitor] Increase block sync check time

### DIFF
--- a/indexer-monitor/src/index.ts
+++ b/indexer-monitor/src/index.ts
@@ -363,7 +363,7 @@ async function main() {
 
     setInterval(checkPing, 5 * 1000, indexerAPI, targetEmail);
     setInterval(checkFollowUp, 10 * 1000, indexerAPI, targetEmail);
-    setInterval(checkBlockSync, 5 * 60 * 1000, indexerAPI, targetEmail);
+    setInterval(checkBlockSync, 60 * 60 * 1000, indexerAPI, targetEmail);
 }
 
 main().catch(error => {


### PR DESCRIPTION
The original intention was sending an alarm when a CodeChain node's
height is not changed for more than 1 hour. Currently, the time is 5
minutes. I think that it was a mistake.