### PR TITLE
[fee-monitor] Quit the process when the main function throws

### DIFF
--- a/fee-monitor/src/index.ts
+++ b/fee-monitor/src/index.ts
@@ -144,13 +144,15 @@ function createWatchdog(timeout: number): Watchdog<Progress> {
     return dog;
 }
 
+let setIntervalId: any = null;
+
 async function main() {
     let blockNumber = await startFrom();
 
     let lastReportedBlockNumber = blockNumber;
     let lastReportedDate = new Date().getUTCDate();
     const dynamicChecker = new DynamicChecker();
-    setInterval(() => {
+    setIntervalId = setInterval(() => {
         (async () => {
             const now = new Date();
             if (now.getUTCDate() === lastReportedDate) {
@@ -206,5 +208,8 @@ main().catch(error => {
     console.log({ error });
     slack.sendError(error);
     email.sendError(error.message);
+    if (setIntervalId != null) {
+        clearInterval(setIntervalId);
+    }
     throw error;
 });


### PR DESCRIPTION
The fee monitor cannot recover when the main function throws an error. The desired behavior is that killing the process. Since the event loop has the setInterval job, the thread was not killed. By calling the `clearInterval` function, we can quit the process.

This PR does not fix the #137, but if this PR merged, the fee monitor will not say that it is healthy even though it is not doing anything useful.