### PR TITLE
[fee-monitor] Do not fail when an RPC request failed

### DIFF
--- a/fee-monitor/src/index.ts
+++ b/fee-monitor/src/index.ts
@@ -189,6 +189,7 @@ async function main() {
                     data: { blockNumber, retry },
                 });
                 await checkBlock(blockNumber, dynamicChecker);
+                blockNumber = await getNextBlockNumber(blockNumber);
                 break;
             } catch (e) {
                 if (retry === 10) {
@@ -199,7 +200,6 @@ async function main() {
                 await new Promise(resolve => setTimeout(resolve, 1000 * retry));
             }
         }
-        blockNumber = await getNextBlockNumber(blockNumber);
         fs.writeFileSync(`lastBlockNumber.${SERVER}`, blockNumber.toString(10), "utf8");
     }
 }


### PR DESCRIPTION
The fee monitor retries ten times when the RPC server does not respond. However, there was an RPC call outside of the retry loop. I moved the RPC call inside the loop.

This PR fixes https://github.com/CodeChain-io/cron-jobs/issues/137