### PR TITLE
Bump the PostgreSQL version used in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,5 +83,5 @@ services:
   - docker
   - postgresql
 addons:
-  postgresql: "9.4"
+  postgresql: "9.5"
 cache: yarn


### PR DESCRIPTION
The indexer is using a new syntax available in the PostgreSQL 9.5.                                             
                                                                                                         
https://github.com/CodeChain-io/codechain-indexer/blob/3d29ef69a4dca6dba427ce4e41d7142193b0f557/.travis.yml#L34