### PR TITLE
[monitor] Make monitor send info messages to slack

### DIFF
--- a/monitor/index.ts
+++ b/monitor/index.ts
@@ -36,13 +36,11 @@ function colorFromLevel(
 
 function sendNotice(error: Notification, targetEmail: string) {
   const color = colorFromLevel(error.level);
-  if (color != null) {
-    SlackNotification.instance.send({
-      title: error.title,
-      text: error.content,
-      color
-    });
-  }
+  SlackNotification.instance.send({
+    title: error.title,
+    text: error.content,
+    color
+  });
   if (error.level === "error") {
     emailClient
       .sendAnnouncement(


### PR DESCRIPTION
The color of info message is `undefined`. Make monitor to send
messages with `undefined` color.